### PR TITLE
Security: Bump joi module to fix npm vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-trebuchet",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -885,9 +885,12 @@
       }
     },
     "@hapi/address": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
-      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
+      "version": "4.0.0",
+      "resolved": "https://npm.tescloud.com/@hapi%2faddress/-/address-4.0.0.tgz",
+      "integrity": "sha512-GDDpkCdSUfkQCznmWUHh9dDN85BWf/V8TFKQ2JLuHdGB4Yy3YTEGBzZxoBNxfNBEvreSR/o+ZxBBSNNEVzY+lQ==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
     },
     "@hapi/boom": {
       "version": "9.0.0",
@@ -898,52 +901,38 @@
       }
     },
     "@hapi/formula": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
-      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+      "version": "2.0.0",
+      "resolved": "https://npm.tescloud.com/@hapi%2fformula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
     },
     "@hapi/hoek": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.0.tgz",
-      "integrity": "sha512-XxD4A5YMIH70ddjG7BJBUz7RWVQAwIP/36Eoyh0DsaWp92OAeXkrbtSEaYkynBPTsN9Uv2mZq9QWZYILl2Svrw=="
+      "version": "9.0.3",
+      "resolved": "https://npm.tescloud.com/@hapi%2fhoek/-/hoek-9.0.3.tgz",
+      "integrity": "sha512-jKtjLLDiH95b002sJVc5c74PE6KKYftuyVdVmsuYId5stTaWcRFqE+5ukZI4gDUKjGn8wv2C3zPn3/nyjEI7gg=="
     },
     "@hapi/joi": {
-      "version": "16.1.8",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.8.tgz",
-      "integrity": "sha512-wAsVvTPe+FwSrsAurNt5vkg3zo+TblvC5Bb1zMVK6SJzZqw9UrJnexxR+76cpePmtUZKHAPxcQ2Bf7oVHyahhg==",
+      "version": "17.1.0",
+      "resolved": "https://npm.tescloud.com/@hapi%2fjoi/-/joi-17.1.0.tgz",
+      "integrity": "sha512-ob67RcPlwRWxBzLCnWvcwx5qbwf88I3ykD7gcJLWOTRfLLgosK7r6aeChz4thA3XRvuBfI0KB1tPVl2EQFlPXw==",
       "requires": {
-        "@hapi/address": "^2.1.2",
-        "@hapi/formula": "^1.2.0",
-        "@hapi/hoek": "^8.2.4",
-        "@hapi/pinpoint": "^1.0.2",
-        "@hapi/topo": "^3.1.3"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
+        "@hapi/address": "^4.0.0",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
       }
     },
     "@hapi/pinpoint": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
-      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
+      "version": "2.0.0",
+      "resolved": "https://npm.tescloud.com/@hapi%2fpinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
     },
     "@hapi/topo": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
-      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "version": "5.0.0",
+      "resolved": "https://npm.tescloud.com/@hapi%2ftopo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
       "requires": {
-        "@hapi/hoek": "^8.3.0"
-      },
-      "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-          "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
-        }
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-trebuchet",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Tiny express library to help with s3 uploads and downloads initiated from the browser",
   "main": "lib/index.js",
   "repository": {
@@ -8,7 +8,11 @@
     "url": "https://github.com/tes/s3-trebuchet.git"
   },
   "keywords": [
-    "fetch", "s3", "aws", "upload", "signed urls"
+    "fetch",
+    "s3",
+    "aws",
+    "upload",
+    "signed urls"
   ],
   "scripts": {
     "test": "mocha ./test"
@@ -40,7 +44,7 @@
   },
   "dependencies": {
     "@hapi/boom": "^9.0.0",
-    "@hapi/joi": "^16.1.8",
+    "@hapi/joi": "^17.1.0",
     "aws-sdk": "^2.598.0",
     "crypto": "^1.0.1",
     "debug": "^4.1.1",


### PR DESCRIPTION
This PR is to remove npm vulnerability in @hapi/joi. Please see https://npmjs.com/advisories/1468 for more details