### PR TITLE
Add keyPrefix parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ You can find an example inside the [example folder](example)
 | region                         | `string`             | eu-west-1       | s3 region 
 | maxFileSize                    | `number`             |                 | Acceptable content length upper limit
 | urlExpiryMilliseconds          | `number`             | 1800000         | Default signed urls expiration in ms
+| keyPrefix                      | `string`             |                 | Prepended string to the generated key uuid

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,7 @@ module.exports = ({
   region = DEFAULT_REGION,
   urlExpiryMilliseconds = THIRTY_MINUTES_IN_MILLISECONDS,
   s3ForcePathStyle = false,
+  keyPrefix = '',
 }) => {
   const awsConfig = {
     region,
@@ -43,7 +44,7 @@ module.exports = ({
   };
 
   const getMultipartParams = async () => {
-    const key = uuid();
+    const key = `${keyPrefix}${uuid()}`;
     const policy = {
       expiration: getExpiration(urlExpiryMilliseconds),
       conditions: [


### PR DESCRIPTION
The `keyPrefix` parameter is a string that will be used a prefix for the generated key uuid. This is a useful trick to quickly identify related files, for example you can add a `document id` to different files belonging to the same document. 